### PR TITLE
solve #58

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ REPLICA_TESTS := $(REPLICA_TESTS_DHALL:.dhall=.json)
 
 DEST = ${HOME}/.local/bin
 
+build: src/Replica/Version.idr
+	idris2 --build replica.ipkg
+
 FORCE:
 
 src/Replica/Version.idr: FORCE # We force the update of the version on build
@@ -18,12 +21,9 @@ src/Replica/Version.idr: FORCE # We force the update of the version on build
 	echo "version : String" >> src/Replica/Version.idr
 	echo "version = \"`git describe --tags`\"" >> src/Replica/Version.idr
 
-build: src/Replica/Version.idr
-	idris2 --build replica.ipkg
-
 install: build
 	mkdir -p ${DEST}
-	${RM} ${DEST}/replica
+	# ${RM} ${DEST}/replica
 	cp -r build/exec/* ${DEST}
 
 clean-test:

--- a/README.md
+++ b/README.md
@@ -353,8 +353,8 @@ The main motivation of using dhall is:
 - type safety;
 - ease to generate a set of similar tests.
 
-## Writing tests
 
+## Writing tests
 
 ### `command`
 

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1620759905,
-        "narHash": "sha256-WiyWawrgmyN0EdmiHyG2V+fqReiVi8bM9cRdMaKQOFg=",
+        "lastModified": 1631561581,
+        "narHash": "sha256-3VQMV5zvxaVLvqqUrNz3iJelLw30mIVSfZmAaauM3dA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b543720b25df6ffdfcf9227afafc5b8c1fabfae8",
+        "rev": "7e5bf3925f6fbdfaf50a2a7ca0be2879c4261d19",
         "type": "github"
       },
       "original": {
@@ -23,14 +23,15 @@
         "idris-emacs-src": "idris-emacs-src",
         "nixpkgs": [
           "nixpkgs"
-        ]
+        ],
+        "nixpkgs-chez-racket": "nixpkgs-chez-racket"
       },
       "locked": {
-        "lastModified": 1621286848,
-        "narHash": "sha256-ZQaRlsVYj9JL2ZXqViQO4uU8qmOP9e28uhzq0+vwwrU=",
+        "lastModified": 1632512335,
+        "narHash": "sha256-PfhOjUdPS9frBG2ouHdK5CvbS1jro25/uSVsGvMfcJ0=",
         "owner": "idris-lang",
         "repo": "Idris2",
-        "rev": "2f66f3e006bbbe73605db30cdb8c2464d41bb49c",
+        "rev": "a9ccf4db4f69677c5287a1278ab167247dac161d",
         "type": "github"
       },
       "original": {
@@ -57,16 +58,32 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1621290140,
-        "narHash": "sha256-J26tkCmjDejI3cdu1GSf3UR+uH3NGYrAzz9spyUnXNM=",
+        "lastModified": 1632600271,
+        "narHash": "sha256-2WndMSEsdnamVktLmYLd8dZrRsGCH5Bd8mu5L4HuupU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c9587434922830fa2657febf05adb91dc866713d",
+        "rev": "6201954aa117d24cc73e46f355c0ea19b8fcad6f",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
         "type": "indirect"
+      }
+    },
+    "nixpkgs-chez-racket": {
+      "locked": {
+        "lastModified": 1627484694,
+        "narHash": "sha256-UsEb5G0ZJ8l/2y9u9FNj2akXx2PC5QAan24U3t32cfI=",
+        "owner": "L-as",
+        "repo": "nixpkgs",
+        "rev": "9b3c4bee8cee477ac03b0cfd4ebca40954c66106",
+        "type": "github"
+      },
+      "original": {
+        "owner": "L-as",
+        "ref": "chez-racket",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,10 @@
         projectName = "replica";
         src = ./.;
         idrisLibraries = [];
+        preBuild = ''
+          make
+        '';
+
       };
     in rec {
       packages = pkgs // idrisPkgs;


### PR DESCRIPTION
I took a stab at https://github.com/ReplicaTest/REPLica/issues/58 because now my tests fail because the
`let Replica = https://raw.githubusercontent.com/berewt/REPLica/main/dhall/replica.dhall has become a 404.` I had in my dhall files is now a 404 (any way to reference a local file, from the flake for instance so that I dont need Internet to run the test).

so the idris flake replica builds upon has its own facility (I thought it would use nixpkgs' ones) and it lacks some `runHook preBuild` calls to run custom code before their own https://github.com/idris-lang/Idris2/blob/master/nix/buildIdris.nix#L25, hencem y changes.

Now this still fails with 
```
$ nix build                                                      
warning: Git tree '/home/teto/REPLica' is dirty
note: keeping build directory '/tmp/nix-build-replica.drv-8'
error: builder for '/nix/store/xrsjy4jx18rxdbyypw6wnpf3gf6w145k-replica.drv' failed with exit code 1;
       last 10 log lines:
       >
       > Replica.App.FileSystem:42:21--42:26
       >  38 | export
       >  39 | Has [PrimIO, Exception FSError] e => FileSystem e where
       >  40 |   createDir d = do
       >  41 |     Right x <- primIO $ createDir d
       >  42 |       | Left err => throw (toFSError err d)
       >                           ^^^^^
       >
       > Suggestion: add an explicit export or public export modifier. By default, all names are private in namespace blocks.
       For full logs, run 'nix log /nix/store/xrsjy4jx18rxdbyypw6wnpf3gf6w145k-replica.drv'.
```
